### PR TITLE
利用しないグラフの非表示

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -147,11 +147,11 @@ export default {
           link:
             'https://www.seisakukikaku.metro.tokyo.lg.jp/information/event02.html'
         },
-        {
-          title: this.$t('Message from Governor Koike'),
-          link:
-            'https://www.metro.tokyo.lg.jp/tosei/governor/governor/katsudo/2020/03/03_00.html'
-        },
+        //{
+        //  title: this.$t('Message from Governor Koike'),
+        //  link:
+        //    'https://www.metro.tokyo.lg.jp/tosei/governor/governor/katsudo/2020/03/03_00.html'
+        //},
         {
           title: this.$t('About us'),
           link: '/about'

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,18 +14,6 @@
     />
     <v-row class="DataBlock">
       <v-col cols="12" md="6" class="DataCard">
-        <svg-card
-          title="検査陽性者の状況"
-          :title-id="'details-of-confirmed-cases'"
-          :date="headerItem.date"
-        >
-          <confirmed-cases-table
-            aria-label="検査陽性者の状況"
-            v-bind="confirmedCases"
-          />
-        </svg-card>
-      </v-col>
-      <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
           title="陽性患者数"
           :title-id="'number-of-confirmed-cases'"
@@ -50,6 +38,19 @@
             'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'
           "
         />
+      </v-col>
+      <!--
+      <v-col cols="12" md="6" class="DataCard">
+        <svg-card
+          title="検査陽性者の状況"
+          :title-id="'details-of-confirmed-cases'"
+          :date="headerItem.date"
+        >
+          <confirmed-cases-table
+            aria-label="検査陽性者の状況"
+            v-bind="confirmedCases"
+          />
+        </svg-card>
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
         <time-stacked-bar-chart
@@ -95,6 +96,7 @@
           :date="metroGraph.date"
         />
       </v-col>
+      -->
     </v-row>
   </div>
 </template>


### PR DESCRIPTION
## 📝 関連issue/Related issue
- issue運用がないため現在時点ではなし。

## ⛏ 変更内容/Change details
- グラフの表示を「陽性患者数」と「陽性患者の属性」のみに変更
- サイドバーの「都知事からのメッセージ」をコメントアウト

## 📸 スクリーンショット/Screenshot

修正したスクリーンショット

![image](https://user-images.githubusercontent.com/18080622/76622926-d063c580-6575-11ea-926f-5d023d1954d4.png)


参考のすくりーんしょっとスクリーンショット
![image](https://user-images.githubusercontent.com/18080622/76623028-fd17dd00-6575-11ea-86c5-ed1b476906fc.png)
