### PR TITLE
チャートのtooltipをデータから取るように変更

### DIFF
--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -134,7 +134,7 @@ export default {
                     `${itemTitle}: ${data[index][tooltipItem.index]}`
                 )
                 .reduce((acc, labelByTitle) => `${acc} / ${labelByTitle}`)
-              return `${selectedSum} (${sumByTitle})`
+              return `${selectedSum}（${sumByTitle}）`
             },
             title(tooltipItem, data) {
               return data.labels[tooltipItem[0].index].replace(

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -1,6 +1,6 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
-    <template v-slot:button>
+    <template #button>
       <data-selector v-model="dataKind" />
     </template>
     <bar
@@ -9,7 +9,7 @@
       :options="options"
       :height="240"
     />
-    <template v-slot:infoPanel>
+    <template #infoPanel>
       <data-view-basic-info-panel
         :l-text="displayInfo.lText"
         :s-text="displayInfo.sText"
@@ -17,11 +17,7 @@
       />
     </template>
     <template #supplement>
-      <p class="Graph-Desc">
-        無症状病原体保有者：症状は無いがＰＣＲ検査が陽性だった者で、
-        他者へ感染させる可能性は低いとみられている。（出典：厚生労働省Ｑ＆Ａ一部改
-        変）
-      </p>
+      <slot name="supplement" />
     </template>
   </data-view>
 </template>
@@ -126,28 +122,19 @@ export default {
       const unit = this.unit
       const sumArray = this.eachArraySum(this.chartData)
       const data = this.chartData
-      const cumulativeData = this.chartData.map(item => {
-        return this.cumulative(item)
-      })
-      const cumulativeSumArray = this.eachArraySum(cumulativeData)
       return {
         tooltips: {
           displayColors: false,
           callbacks: {
             label: tooltipItem => {
-              const labelText =
-                this.dataKind === 'transition'
-                  ? `${sumArray[tooltipItem.index]}${unit}（陽性患者: ${
-                      data[0][tooltipItem.index]
-                    }/無症状病原体保有者: ${data[1][tooltipItem.index]}）`
-                  : `${
-                      cumulativeSumArray[tooltipItem.index]
-                    }${unit}（陽性患者: ${
-                      cumulativeData[0][tooltipItem.index]
-                    }/無症状病原体保有者: ${
-                      cumulativeData[1][tooltipItem.index]
-                    }）`
-              return labelText
+              const selectedSum = `${sumArray[tooltipItem.index]}${unit}`
+              const sumByTitle = this.items
+                .map(
+                  (itemTitle, index) =>
+                    `${itemTitle}: ${data[index][tooltipItem.index]}`
+                )
+                .reduce((acc, labelByTitle) => `${acc} / ${labelByTitle}`)
+              return `${selectedSum} (${sumByTitle})`
             },
             title(tooltipItem, data) {
               return data.labels[tooltipItem[0].index].replace(

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -48,7 +48,15 @@
           :items="patientsAndNoSymptomsItems"
           :labels="patientsAndNoSymptomsLabels"
           :unit="'件'"
-        />
+        >
+          <template #supplement>
+            <p class="Graph-Desc">
+              無症状病原体保有者：症状は無いがＰＣＲ検査が陽性だった者で、
+              他者へ感染させる可能性は低いとみられている。（出典：厚生労働省Ｑ＆Ａ一部改
+              変）
+            </p>
+          </template>
+        </time-stacked-bar-chart>
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
         <data-table


### PR DESCRIPTION
## 📝 関連issue/Related issue
https://civictechzenchiba.slack.com/archives/CVDRA3TAB/p1584578808121200?thread_ts=1584550612.106200&cid=CVDRA3TAB

## ⛏ 変更内容/Change details
- チャートのtooltipをデータから取るように変更

## 📸 スクリーンショット/Screenshot
| after | before |
|--|--|
| ![image](https://user-images.githubusercontent.com/1481277/77021651-ab82ae80-69ca-11ea-83ec-26dc149d04d2.png) | ![image](https://user-images.githubusercontent.com/1481277/77021629-986fde80-69ca-11ea-94b9-3e1cf3bf6b37.png) |