### PR TITLE
トップの「最新のお知らせ」見出しをh3タグに変更

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="WhatsNew" :class="{ expanded }">
     <div class="WhatsNew-wrapper">
-      <h2 class="WhatsNew-heading">
+      <h3 class="WhatsNew-heading">
         <v-icon size="24" class="WhatsNew-heading-icon">
           mdi-information
         </v-icon>
         最新のお知らせ
-      </h2>
+      </h3>
       <ul class="WhatsNew-list">
         <li v-for="(item, i) in items" :key="i" class="WhatsNew-list-item">
           <a


### PR DESCRIPTION
## 📝 関連issue/Related issue
- close #196 

## ⛏ 変更内容/Change details
- h2からh3タグに修正しました。

## 📸 スクリーンショット/Screenshot
### 修正前
![h2_prod](https://user-images.githubusercontent.com/1600298/78683090-d1480700-7929-11ea-8eb6-0c0649d12195.jpg)

### 修正後
![h3_dev](https://user-images.githubusercontent.com/1600298/78683112-d86f1500-7929-11ea-9c7d-c2d73ab761f7.jpg)
