### PR TITLE
TextCardの見出しをh3に、pタグをdivに変更

### DIFF
--- a/components/TextCard.vue
+++ b/components/TextCard.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="TextCard">
-    <h2 v-if="title" class="TextCard-Heading">
+    <h3 v-if="title" class="TextCard-Heading">
       {{ title }}
-    </h2>
+    </h3>
     <!-- eslint-disable-next-line vue/no-v-html -->
     <p v-if="body" class="TextCard-Body" v-html="body" />
     <p class="TextCard-Body">

--- a/components/TextCard.vue
+++ b/components/TextCard.vue
@@ -4,10 +4,10 @@
       {{ title }}
     </h3>
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <p v-if="body" class="TextCard-Body" v-html="body" />
-    <p class="TextCard-Body">
+    <div v-if="body" class="TextCard-Body" v-html="body" />
+    <div v-if="$slots.default" class="TextCard-Body">
       <slot />
-    </p>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
## 📝 関連issue/Related issue
- close #195 

## ⛏ 変更内容/Change details
- TextCardのh2をh3に変更し、about/parent/workerページの見出し階層構造を修正
- TextCardのpタグをdivに変更し、aboutページでpタグの中にulタグが入る構文エラーを修正

## 📸 スクリーンショット/Screenshot
### 変更前
![prod](https://user-images.githubusercontent.com/1600298/78808797-e93e8a00-7a00-11ea-8c62-7928544ad0a6.jpg)

### 変更後
![dev](https://user-images.githubusercontent.com/1600298/78808810-ee9bd480-7a00-11ea-8439-3bfe0f60ebf0.jpg)