### PR TITLE
fix:slack-invite-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Issues にあるいろいろな修正にご協力いただけると嬉しいで�
 基本的な情報共有は CivicTechZenChiba の Slack にて行っております。
 以下招待リンクよりご参加ください。
 
-https://join.slack.com/t/civictechzenchiba/shared_invite/zt-co2ez9no-IrVcqEBgofajrM_pp~q8_A
+https://join.slack.com/t/civictechzenchiba/shared_invite/zt-dnurg6f9-tta8UTbhd0fP58dFiBzOMQ
 
 ## 行動原則
 詳しくは[サイト構築にあたっての行動原則](./.github/CODE_OF_CONDUCT.md)を御覧ください。

--- a/README_EN.md
+++ b/README_EN.md
@@ -19,7 +19,7 @@ Please check [How to contribute](./.github/CONTRIBUTING_EN.md) for details.
 Basic information is shared on Civic Tech Zen Chiba's Slack.
 Please join us by following the invitation link.
 
-https://join.slack.com/t/civictechzenchiba/shared_invite/zt-co2ez9no-IrVcqEBgofajrM_pp~q8_A
+https://join.slack.com/t/civictechzenchiba/shared_invite/zt-dnurg6f9-tta8UTbhd0fP58dFiBzOMQ
 
 ## Code of Conduct
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -19,7 +19,7 @@ Por favor, consulte [Cómo contribuir](./.github/CONTRIBUTING_ES.md) para obtene
 Se comparte información básica en Civic Tech Zen Chiba's Slack.
 Por favor, únase a nosotros a través del enlace de invitación.
 
-https://join.slack.com/t/civictechzenchiba/shared_invite/zt-co2ez9no-IrVcqEBgofajrM_pp~q8_A
+https://join.slack.com/t/civictechzenchiba/shared_invite/zt-dnurg6f9-tta8UTbhd0fP58dFiBzOMQ
 
 ## Código de Conducta
 


### PR DESCRIPTION
## 📝 関連issue/Related issue
<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #284

## ⛏ 変更内容/Change details
<!-- 変更を端的に箇条書きで -->
<!-- Please concisely list the changes -->
- Slackの招待リンクが無効になっていた
	- 無期限の招待リンクを作成した
