### PR TITLE
検査陽性者の状況のグラフを改善する

### DIFF
--- a/components/ConfirmedCasesDetailsTable.vue
+++ b/components/ConfirmedCasesDetailsTable.vue
@@ -1,13 +1,15 @@
 <template>
   <ul :class="$style.container">
-    <li :class="[$style.pillar_inspection]">
-      <span>
-        検査実施人数
-      </span>
-      <span>
-        <strong>{{ 検査実施人数.toLocaleString() }}</strong>
-        <span :class="$style.unit">人</span>
-      </span>
+    <li :class="[$style.box, $style.pillar_inspection]">
+      <div :class="$style.content">
+        <span>
+          検査実施人数
+        </span>
+        <span>
+          <strong>{{ 検査実施人数.toLocaleString() }}</strong>
+          <span :class="$style.unit">人</span>
+        </span>
+      </div>
     </li>
     <li :class="[$style.box, $style.parent]">
       <div :class="$style.content">
@@ -169,25 +171,6 @@ $default-boxdiff: 35px;
   }
 }
 
-.pillar_inspection {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  border: $default-bdw solid $gray-1;
-  color: $gray-1;
-  padding: 5px 10px;
-  text-align: left;
-
-  strong {
-    @include font-size(16);
-  }
-
-  span.unit {
-    @include font-size(14);
-  }
-}
-
 .group {
   flex: 0 0 auto;
   padding-left: $default-bdw !important;
@@ -263,6 +246,14 @@ $default-boxdiff: 35px;
       border-bottom: none;
     }
   }
+
+  &.pillar_inspection {
+    color: $gray-1;
+    border: $default-bdw solid $gray-1;
+    > .content {
+      border: none;
+    }
+  }
 }
 
 @function px2vw($px, $vw: 0) {
@@ -274,19 +265,6 @@ $default-boxdiff: 35px;
 }
 
 @mixin override($vw, $bdw, $fz, $boxdiff) {
-  .pillar_inspection {
-    padding: px2vw(5, $vw) px2vw(10, $vw);
-    border: px2vw($bdw, $vw) solid $gray-1;
-
-    strong {
-      @include font-size($fz + 2);
-    }
-
-    span.unit {
-      @include font-size($fz);
-    }
-  }
-
   .group {
     padding-left: px2vw($bdw, $vw) !important;
     border-top: px2vw($bdw, $vw) solid $green-1;
@@ -335,6 +313,10 @@ $default-boxdiff: 35px;
         margin-left: -(px2vw($boxdiff, $vw) - px2vw($bdw, $vw) * 2);
         width: calc(100% + #{(px2vw($boxdiff, $vw) - px2vw($bdw, $vw) * 2)});
       }
+    }
+
+    &.pillar_inspection {
+      border: px2vw($bdw, $vw) solid $gray-1;
     }
   }
 }

--- a/components/ConfirmedCasesDetailsTable.vue
+++ b/components/ConfirmedCasesDetailsTable.vue
@@ -115,29 +115,6 @@ export default Vue.extend({
       type: Number,
       required: true
     }
-  },
-  methods: {
-    /** 桁数に応じて位置の調整をする */
-    getAdjustX(input: number) {
-      const length = input.toString(10).length
-      switch (length) {
-        case 1: {
-          return 3
-        }
-        case 2: {
-          return 0
-        }
-        case 3: {
-          return -3
-        }
-        case 4: {
-          return -8
-        }
-        default: {
-          return 0
-        }
-      }
-    }
   }
 })
 </script>

--- a/components/ConfirmedCasesDetailsTable.vue
+++ b/components/ConfirmedCasesDetailsTable.vue
@@ -1,52 +1,42 @@
 <template>
   <ul :class="$style.container">
-    <li :class="[$style.box, $style.tall, $style.inspection]">
-      <div :class="$style.pillar_inspection">
-        <div :class="$style.content">
-          <span>
-            検査実施
-            <br />人数
-          </span>
-          <span>
-            <strong>{{ 検査実施人数.toLocaleString() }}</strong>
-            <span :class="$style.unit">人</span>
-          </span>
-        </div>
-      </div>
+    <li :class="[$style.pillar_inspection]">
+      <span>
+        検査実施人数
+      </span>
+      <span>
+        <strong>{{ 検査実施人数.toLocaleString() }}</strong>
+        <span :class="$style.unit">人</span>
+      </span>
     </li>
-    <li :class="[$style.box, $style.tall, $style.parent, $style.confirmed]">
-      <div :class="$style.pillar">
-        <div :class="$style.content">
-          <span>
-            陽性患者
-            <br />(累計)
-          </span>
-          <span>
-            <strong>{{ 陽性患者.toLocaleString() }}</strong>
-            <span :class="$style.unit">人</span>
-          </span>
-        </div>
+    <li :class="[$style.box, $style.parent]">
+      <div :class="$style.content">
+        <span>
+          陽性患者(累計)
+        </span>
+        <span>
+          <strong>{{ 陽性患者.toLocaleString() }}</strong>
+          <span :class="$style.unit">人</span>
+        </span>
       </div>
       <ul :class="$style.group">
-        <li :class="[$style.box, $style.parent, $style.hospitalized]">
-          <div :class="$style.pillar">
-            <div :class="$style.content">
-              <!-- eslint-disable vue/no-v-html-->
-              <span v-html="$t('現在の<br />感染者')" />
-              <!-- eslint-enable vue/no-v-html-->
-              <span>
-                <strong>{{ 現在の感染者.toLocaleString() }}</strong>
-                <span :class="$style.unit">人</span>
-              </span>
-            </div>
+        <li :class="[$style.box, $style.parent]">
+          <div :class="$style.content">
+            <span>
+              {{ $t('現在の感染者') }}
+            </span>
+            <span>
+              <strong>{{ 現在の感染者.toLocaleString() }}</strong>
+              <span :class="$style.unit">人</span>
+            </span>
           </div>
           <ul :class="$style.group">
             <li :class="[$style.box, $style.short, $style.minor]">
               <div :class="$style.pillar">
                 <div :class="$style.content">
-                  <!-- eslint-disable vue/no-v-html-->
-                  <span v-html="$t('軽症・<br />中等症')" />
-                  <!-- eslint-enable vue/no-v-html-->
+                  <span>
+                    {{ $t('軽症・中等症') }}
+                  </span>
                   <span>
                     <strong>{{ 軽症中等症.toLocaleString() }}</strong>
                     <span :class="$style.unit">人</span>
@@ -67,7 +57,7 @@
             </li>
           </ul>
         </li>
-        <li :class="[$style.box, $style.deceased]">
+        <li :class="[$style.box]">
           <div :class="$style.pillar">
             <div :class="$style.content">
               <span>死亡</span>
@@ -78,12 +68,12 @@
             </div>
           </div>
         </li>
-        <li :class="[$style.box, $style.recovered]">
+        <li :class="[$style.box]">
           <div :class="$style.pillar">
             <div :class="$style.content">
-              <!-- eslint-disable vue/no-v-html-->
-              <span v-html="$t('退院・<br />療養終了')" />
-              <!-- eslint-enable vue/no-v-html-->
+              <span>
+                {{ $t('退院・療養終了') }}
+              </span>
               <span>
                 <strong>{{ 退院_療養終了.toLocaleString() }}</strong>
                 <span :class="$style.unit">人</span>
@@ -158,142 +148,123 @@ export default Vue.extend({
 
 <style lang="scss" module>
 $default-bdw: 3px;
-$default-boxh: 150px;
 $default-boxdiff: 35px;
+
 // .container > .box > (.group > .box > ...) .pillar > .content
+
 .container {
   width: 100%;
-  display: flex;
-  justify-content: center;
   box-sizing: border-box;
+  color: $green-1;
   line-height: 1.35;
+
   * {
     box-sizing: border-box;
   }
   // override default styles
   padding-left: 0 !important;
+
   ul {
     padding-left: 0;
   }
 }
-.pillar {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  flex: 0 0 auto;
-  text-align: center;
-  width: 100%;
-  border: $default-bdw solid $green-1;
-  color: $green-1;
-}
+
 .pillar_inspection {
   display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  flex: 0 0 auto;
-  text-align: center;
+  justify-content: space-between;
+  align-items: center;
   width: 100%;
-  border-right: $default-bdw solid $gray-1;
-  border-bottom: $default-bdw solid $gray-1;
+  border: $default-bdw solid $gray-1;
   color: $gray-1;
+  padding: 5px 10px;
+  text-align: left;
+
+  strong {
+    @include font-size(16);
+  }
+
+  span.unit {
+    @include font-size(14);
+  }
 }
+
 .group {
-  display: flex;
   flex: 0 0 auto;
-  padding-left: 0;
-  padding-top: $default-bdw;
+  padding-left: $default-bdw !important;
   border-top: $default-bdw solid $green-1;
   border-left: $default-bdw solid $green-1;
 }
-.box {
+
+.content {
+  padding: 5px 10px;
   display: flex;
-  &.inspection {
-    border-top: $default-bdw solid $gray-1;
-    border-left: $default-bdw solid $gray-1;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  border: $default-bdw solid $green-1;
+
+  > span {
+    display: block;
+
+    @include font-size(14);
+
+    &:first-child {
+      text-align: left;
+      margin-top: 1px;
+      flex-shrink: 2;
+    }
+
+    &:last-child {
+      margin-left: 10px;
+      text-align: right;
+      // white-space: nowrap;
+      flex-shrink: 1;
+    }
+
+    &:not(:last-child) {
+      overflow-wrap: break-word;
+    }
   }
+
+  strong {
+    @include font-size(16);
+  }
+
+  span.unit {
+    @include font-size(14);
+  }
+}
+
+.box {
+  display: block;
+  margin-top: $default-bdw;
+
   &.parent {
     border-top: $default-bdw solid $green-1;
     border-left: $default-bdw solid $green-1;
     position: relative;
-    padding-top: $default-boxdiff - $default-bdw * 2;
+    padding-left: $default-boxdiff - $default-bdw * 2;
+
     &::after {
       content: '';
       display: block;
       position: absolute;
-      top: -1px;
-      right: 0;
-      height: $default-boxdiff - $default-bdw - 2;
-      border-left: $default-bdw solid $green-1;
+      left: -1px;
+      bottom: 0;
+      width: $default-boxdiff - $default-bdw - 2;
+      border-bottom: $default-bdw solid $green-1;
     }
-    > .pillar {
-      margin-top: -($default-boxdiff - $default-bdw * 2);
+
+    > .content {
+      margin-left: -($default-boxdiff - $default-bdw * 2);
+      width: calc(100% + #{($default-boxdiff - $default-bdw * 2)});
       border-top: none;
-      border-right: none;
       border-left: none;
+      border-bottom: none;
     }
-  }
-  &.confirmed {
-    width: 100%;
-    > .pillar {
-      // [6列] 1/6
-      width: calc((100% + #{$default-bdw} * 2) / 6 - #{$default-bdw} * 3);
-    }
-    > .group {
-      // [6列] 5/6
-      width: calc((100% + #{$default-bdw} * 2) / 6 * 5 + #{$default-bdw});
-    }
-  }
-  &.hospitalized {
-    margin-left: $default-bdw;
-    // [5列] 3/5
-    width: calc(100% / 5 * 3 - #{$default-bdw});
-    > .pillar {
-      // [3列] 1/3
-      width: calc((100% + #{$default-bdw} * 2) / 3 - #{$default-bdw} * 3);
-    }
-    > .group {
-      // [3列] 2/3
-      width: calc((100% + #{$default-bdw} * 2) / 3 * 2 + #{$default-bdw});
-    }
-  }
-  &.minor,
-  &.severe {
-    margin-left: $default-bdw;
-    // [2列] 1/2
-    width: calc(100% / 2 - #{$default-bdw});
-  }
-  &.deceased,
-  &.recovered {
-    margin-left: $default-bdw;
-    // [5列] 1/5
-    width: calc(100% / 5 - #{$default-bdw});
   }
 }
-.content {
-  min-height: $default-boxh;
-  padding: 10px 2px;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: center;
-  > span {
-    display: block;
-    width: 100%;
-    @include font-size(16);
-    &:last-child {
-      margin-top: 0.1em;
-    }
-    &:not(:last-child) {
-      word-break: break-all;
-    }
-  }
-  span strong {
-    @include font-size(18);
-  }
-  span.unit {
-    @include font-size(16);
-  }
-}
+
 @function px2vw($px, $vw: 0) {
   @if $vw > 0 {
     @return ceil($px / $vw * 100000vw) / 1000;
@@ -301,110 +272,85 @@ $default-boxdiff: 35px;
     @return $px * 1px;
   }
 }
-@mixin override($vw, $bdw, $fz, $boxh, $boxdiff) {
-  .pillar {
-    border-width: px2vw($bdw, $vw);
-  }
+
+@mixin override($vw, $bdw, $fz, $boxdiff) {
   .pillar_inspection {
-    border-right-width: px2vw($bdw, $vw);
-    border-bottom-width: px2vw($bdw, $vw);
-  }
-  .group {
-    padding-top: px2vw($bdw, $vw);
-    border-top-width: px2vw($bdw, $vw);
-    border-left-width: px2vw($bdw, $vw);
-  }
-  .content {
-    > span {
-      @include font-size($fz);
-    }
-    span strong {
+    padding: px2vw(5, $vw) px2vw(10, $vw);
+    border: px2vw($bdw, $vw) solid $gray-1;
+
+    strong {
       @include font-size($fz + 2);
     }
+
     span.unit {
       @include font-size($fz);
     }
   }
+
+  .group {
+    padding-left: px2vw($bdw, $vw) !important;
+    border-top: px2vw($bdw, $vw) solid $green-1;
+    border-left: px2vw($bdw, $vw) solid $green-1;
+  }
+
+  .content {
+    padding: px2vw(5, $vw) px2vw(10, $vw);
+    border: px2vw($bdw, $vw) solid $green-1;
+
+    > span {
+      @include font-size($fz);
+
+      &:first-child {
+        margin-top: px2vw(1, $vw);
+      }
+
+      &:last-child {
+        margin-left: 10px;
+      }
+    }
+
+    strong {
+      @include font-size($fz + 2);
+    }
+
+    span.unit {
+      @include font-size($fz);
+    }
+  }
+
   .box {
-    &.inspection {
-      border-top-width: px2vw($bdw, $vw);
-      border-left-width: px2vw($bdw, $vw);
-    }
+    margin-top: px2vw($bdw, $vw);
+
     &.parent {
-      border-top-width: px2vw($bdw, $vw);
-      border-left-width: px2vw($bdw, $vw);
-      padding-top: px2vw($boxdiff, $vw) - px2vw($bdw, $vw) * 2;
+      border-top: px2vw($bdw, $vw) solid $green-1;
+      border-left: px2vw($bdw, $vw) solid $green-1;
+      padding-left: px2vw($boxdiff, $vw) - px2vw($bdw, $vw) * 2;
+
       &::after {
-        height: px2vw($boxdiff - $bdw, $vw);
-        border-left-width: px2vw($bdw, $vw);
+        width: px2vw($boxdiff - $bdw, $vw);
+        border-bottom: px2vw($bdw, $vw) solid $green-1;
       }
-      > .pillar {
-        margin-top: px2vw((-($boxdiff - $bdw * 2)), $vw);
+
+      > .content {
+        margin-left: -(px2vw($boxdiff, $vw) - px2vw($bdw, $vw) * 2);
+        width: calc(100% + #{(px2vw($boxdiff, $vw) - px2vw($bdw, $vw) * 2)});
       }
-    }
-    &.confirmed {
-      margin-left: px2vw($bdw, $vw);
-      > .pillar {
-        width: calc(
-          (100% + #{px2vw($bdw, $vw)} * 2) / 6 - #{px2vw($bdw, $vw)} * 3
-        );
-      }
-      > .group {
-        width: calc(
-          (100% + #{px2vw($bdw, $vw)} * 2) / 6 * 5 + #{px2vw($bdw, $vw)}
-        );
-      }
-    }
-    &.hospitalized {
-      margin-left: px2vw($bdw, $vw);
-      width: calc(100% / 5 * 3 - #{px2vw($bdw, $vw)});
-      > .pillar {
-        width: calc(
-          (100% + #{px2vw($bdw, $vw)} * 2) / 3 - #{px2vw($bdw, $vw)} * 3
-        );
-      }
-      > .group {
-        width: calc(
-          (100% + #{px2vw($bdw, $vw)} * 2) / 3 * 2 + #{px2vw($bdw, $vw)}
-        );
-      }
-    }
-    &.minor,
-    &.severe {
-      margin-left: px2vw($bdw, $vw);
-      width: calc(100% / 2 - #{px2vw($bdw, $vw)});
-    }
-    &.deceased,
-    &.recovered {
-      margin-left: px2vw($bdw, $vw);
-      width: calc(100% / 5 - #{px2vw($bdw, $vw)});
     }
   }
 }
-// variables.scss Breakpoints: huge (1440)
-@include lessThan(1440) {
-  @include override(1440, 3, 15, 150, 35);
-}
+
 // Vuetify Breakpoints: Large (1264)
 @include lessThan(1263) {
-  @include override(1263, 2, 13, 107, 24);
+  @include override(1263, 3, 14, 35);
 }
-// variables.scss Breakpoints: large (1170)
-@include lessThan(1170) {
-  @include override(1170, 2, 13, 107, 24);
-}
+
 // Vuetify Breakpoints: Small (960)
 @include lessThan(959) {
-  @include override(960, 4, 14, 180, 40);
+  @include override(960, 3, 14, 35);
 }
-@include lessThan(767) {
-  @include override(960, 3, 14, 180, 40);
-}
+
 // Vuetify Breakpoints: Extra Small (600)
 @include lessThan(600) {
-  @include override(600, 3, 14, 150, 35);
-}
-@include lessThan(420) {
-  @include override(600, 2, 12, 150, 35);
+  @include override(600, 3, 14, 35);
 }
 </style>

--- a/components/ConfirmedCasesDetailsTable.vue
+++ b/components/ConfirmedCasesDetailsTable.vue
@@ -24,9 +24,7 @@
       <ul :class="$style.group">
         <li :class="[$style.box, $style.parent]">
           <div :class="$style.content">
-            <span>
-              {{ $t('現在の感染者') }}
-            </span>
+            <span>現在の感染者</span>
             <span>
               <strong>{{ 現在の感染者.toLocaleString() }}</strong>
               <span :class="$style.unit">人</span>
@@ -36,9 +34,7 @@
             <li :class="[$style.box, $style.short, $style.minor]">
               <div :class="$style.pillar">
                 <div :class="$style.content">
-                  <span>
-                    {{ $t('軽症・中等症') }}
-                  </span>
+                  <span>軽症・中等症</span>
                   <span>
                     <strong>{{ 軽症中等症.toLocaleString() }}</strong>
                     <span :class="$style.unit">人</span>
@@ -73,9 +69,7 @@
         <li :class="[$style.box]">
           <div :class="$style.pillar">
             <div :class="$style.content">
-              <span>
-                {{ $t('退院・療養終了') }}
-              </span>
+              <span>退院・療養終了</span>
               <span>
                 <strong>{{ 退院_療養終了.toLocaleString() }}</strong>
                 <span :class="$style.unit">人</span>


### PR DESCRIPTION
## 📝 関連issue/Related issue
<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #393 

## ⛏ 変更内容/Change details
<!-- 変更を端的に箇条書きで -->
<!-- Please concisely list the changes -->
- 縦の区切りによって幅が狭まると予期せぬ改行が起きて見づらくなっていた
  - 東京都の[コンポーネント](https://github.com/tokyo-metropolitan-gov/covid19/blob/development/components/ConfirmedCasesDetailsTable.vue)を参考に改善
- `v-html`を介入して改行を実現していたものを廃止

## 📸 スクリーンショット/Screenshot
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- For changes to things such as style, including a screenshot will make it easier to review -->
### 改善後
[![Screenshot from Gyazo](https://gyazo.com/157b64c4958bb5a5b6fe1cb7682b2e07/raw)](https://gyazo.com/157b64c4958bb5a5b6fe1cb7682b2e07)

### 改善前
[![Screenshot from Gyazo](https://gyazo.com/b49149110c030a22b110255c6c8d12e0/raw)](https://gyazo.com/b49149110c030a22b110255c6c8d12e0)
