### PR TITLE
検査実施数画面の月表示の日本語化とY軸ラベルのスケールがグラフのスケールと等しくなるようにする

### DIFF
--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -102,7 +102,7 @@ type Computed = {
   displayOption: Chart.ChartOptions
   displayDataHeader: DisplayData
   displayOptionHeader: Chart.ChartOptions
-  scaledTicksYAxisMax: number
+  // scaledTicksYAxisMax: number
   tableHeaders: {
     text: any
     value: string
@@ -408,7 +408,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
-      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+      // const scaledTicksYAxisMax = this.scaledTicksYAxisMax
       const options: Chart.ChartOptions = {
         responsive: true,
         maintainAspectRatio: false,
@@ -494,7 +494,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         animation: { duration: 0 }
       }
       return options
-    },
+    }
+    /*
     scaledTicksYAxisMax() {
       let max = 0
       for (const i in this.chartData[0]) {
@@ -502,6 +503,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
       return max
     }
+    */
   },
   methods: {
     onClickLegend(i) {

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -486,7 +486,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080' // #808080
-                //suggestedMax: scaledTicksYAxisMax
+                // suggestedMax: scaledTicksYAxisMax
               }
             }
           ]

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -327,7 +327,25 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 fontSize: 11,
                 fontColor: '#808080',
                 padding: 3,
-                fontStyle: 'bold'
+                fontStyle: 'bold',
+                callback: (label: string) => {
+                  const monthStringArry = [
+                    'Jan',
+                    'Feb',
+                    'Mar',
+                    'Apr',
+                    'May',
+                    'Jun',
+                    'Jul',
+                    'Aug',
+                    'Sep',
+                    'Oct',
+                    'Nov',
+                    'Dec'
+                  ]
+                  const month = monthStringArry.indexOf(label.split(' ')[0]) + 1
+                  return month + '月'
+                }
               },
               type: 'time',
               time: {
@@ -467,8 +485,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
-                suggestedMax: scaledTicksYAxisMax
+                fontColor: '#808080' // #808080
+                //suggestedMax: scaledTicksYAxisMax
               }
             }
           ]


### PR DESCRIPTION
## 📝 関連issue/Related issue
- close #{[416](https://github.com/civictechzenchiba/covid19-chiba/issues/416)}
- close #{[417](https://github.com/civictechzenchiba/covid19-chiba/issues/417)}

## ⛏ 変更内容/Change details
- 検査実施数について月の表示を英語から日本語に変更。
- 「陰性」「陽性」をクリックした際にY軸ラベルの数値がグラフの表示に合わせて変更されるようにする。

## 📸 スクリーンショット/Screenshot
![covid19-chiba-PR](https://user-images.githubusercontent.com/53452427/88447803-71428580-ce72-11ea-94c2-1f47d4b3d1e5.PNG)

